### PR TITLE
Added support to polymorphic relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,46 @@ class User
 end
 ```
 
+### Options of denormalize
+
+#### inverses\_of: for polymorphic relations
+
+In case where the relation is polymorphic you must add `inverses_of` with the name of the possible clasess of the other side of the relation as:
+
+```ruby
+class Club
+  ...
+  has_many :members
+end
+
+class User
+  ...
+  belogns_to club, inverse_of: :members, polymorphic: true
+
+  denormalize :name, from: :club, inverses_of: %i[club]
+end
+```
+
+#### as: enables to customize the final field name
+
+Only one unique field could be passed as argument, like this:
+
+```ruby
+  denormalize :name, from: :top, as: :supername
+```
+
+It will create a `supername` field with the content of `top.name`.
+
+#### prefix: enables to customize the prefix of the final name
+
+In somes cases it could be interesting to customize the prefix of the final name, instead of using the basic `from_field`
+
+```ruby
+  denormalize :color, :name, from: :top, prefix: :ancestor
+```
+
+It will create the fields `ancestor_name` and `ancestor_color` with the content of `top.name` and `top.color`.
+
 ## Example
 
 ```ruby

--- a/spec/mongoid/denormalize_spec.rb
+++ b/spec/mongoid/denormalize_spec.rb
@@ -80,6 +80,472 @@ RSpec.describe Mongoid::Denormalize do
         end
       end
 
+      context 'when :prefix is used' do
+        context 'when all is ok' do
+          before :all do
+            class Parent
+              include Mongoid::Document
+
+              field :name
+              has_many :children
+            end
+
+            class Child
+              include Mongoid::Document
+              include Mongoid::Denormalize
+
+              belongs_to :parent
+              denormalize :name, from: :parent, prefix: :new_prefix
+            end
+          end
+
+          after :all do
+            Object.send(:remove_const, :Parent)
+            Object.send(:remove_const, :Child)
+          end
+
+          context 'when creates new document' do
+            before do
+              @parent = Parent.create(name: 'name')
+              @child = Child.create(parent: @parent)
+            end
+
+            it 'add childs denormalized fields' do
+              expect(@child.reload.new_prefix_name).to eq(@parent.name)
+            end
+
+            it 'doesn\'t create the old from_field' do
+              expect(@child.reload).not_to respond_to(:parent_name)
+            end
+          end
+
+          context 'when updates relation' do
+            before do
+              parent = Parent.create(name: 'name')
+              @new_parent = Parent.create(name: 'new_name')
+              @child = Child.create(parent: parent)
+              @child.update_attributes(parent: @new_parent)
+            end
+
+            it 'updates childs denormalized fields' do
+              expect(@child.reload.new_prefix_name).to eq(@new_parent.name)
+            end
+
+            it 'doesn\'t create the old from_field' do
+              expect(@child.reload).not_to respond_to(:parent_name)
+            end
+          end
+
+          context 'when updates parent denormalized field' do
+            before do
+              @parent = Parent.create(name: 'name')
+              @child = Child.create(parent: @parent)
+              @parent.update_attributes(name: 'new_fancy_name')
+            end
+
+            it 'updates childs denormalized fields' do
+              expect(@child.reload.new_prefix_name).to eq(@parent.name)
+            end
+
+            it 'doesn\'t create the old from_field' do
+              expect(@child.reload).not_to respond_to(:parent_name)
+            end
+          end
+        end
+
+        context 'when :as is also used' do
+          before :all do
+            class Parent
+              include Mongoid::Document
+
+              field :name
+              has_many :children
+            end
+
+            class Child
+              include Mongoid::Document
+              include Mongoid::Denormalize
+
+              belongs_to :parent
+              denormalize :name, from: :parent, prefix: :new_prefix, as: :supername
+            end
+          end
+
+          after :all do
+            Object.send(:remove_const, :Parent)
+            Object.send(:remove_const, :Child)
+          end
+
+          context 'when creates new document' do
+            before do
+              @parent = Parent.create(name: 'name')
+              @child = Child.create(parent: @parent)
+            end
+
+            it 'add childs denormalized fields' do
+              expect(@child.reload.supername).to eq(@parent.name)
+            end
+
+            it 'doesn\'t create the prefix field' do
+              expect(@child.reload).not_to respond_to(:new_prefix_name)
+            end
+          end
+
+          context 'when updates relation' do
+            before do
+              parent = Parent.create(name: 'name')
+              @new_parent = Parent.create(name: 'new_name')
+              @child = Child.create(parent: parent)
+              @child.update_attributes(parent: @new_parent)
+            end
+
+            it 'updates childs denormalized fields' do
+              expect(@child.reload.supername).to eq(@new_parent.name)
+            end
+
+            it 'doesn\'t create the prefix field' do
+              expect(@child.reload).not_to respond_to(:new_prefix_name)
+            end
+          end
+
+          context 'when updates parent denormalized field' do
+            before do
+              @parent = Parent.create(name: 'name')
+              @child = Child.create(parent: @parent)
+              @parent.update_attributes(name: 'new_fancy_name')
+            end
+
+            it 'updates childs denormalized fields' do
+              expect(@child.reload.supername).to eq(@parent.name)
+            end
+
+            it 'doesn\'t create the prefix field' do
+              expect(@child.reload).not_to respond_to(:new_prefix_name)
+            end
+          end
+        end
+      end
+
+      context 'when :as is used' do
+        context 'when all is ok' do
+          before :all do
+            class Parent
+              include Mongoid::Document
+
+              field :name
+              has_many :children
+            end
+
+            class Child
+              include Mongoid::Document
+              include Mongoid::Denormalize
+
+              belongs_to :parent
+              denormalize :name, from: :parent, as: :supername
+            end
+          end
+
+          after :all do
+            Object.send(:remove_const, :Parent)
+            Object.send(:remove_const, :Child)
+          end
+
+          context 'when updates parent denormalized field' do
+            before do
+              @parent = Parent.create!(name: 'parent')
+              @child = Child.create!(parent: @parent)
+
+              @parent.update_attributes(name: 'new_name')
+            end
+
+            it 'updates childs denormalized fields' do
+              expect(@child.reload.supername).to eq(@parent.name)
+            end
+
+            it 'doesn\'t create the old from_field' do
+              expect(@child.reload).not_to respond_to(:parent_name)
+            end
+          end
+
+          context 'when updates relation' do
+            before do
+              parent = Parent.create!(name: 'parent')
+              @child = Child.create!(parent: parent)
+
+              @new_parent = Parent.create!(name: 'new_parent')
+              @child.update_attributes(parent: @new_parent)
+            end
+
+            it 'updates denormalized fields' do
+              expect(@child.reload.supername).to eq(@new_parent.name)
+            end
+
+            it 'doesn\'t create the old from_field' do
+              expect(@child.reload).not_to respond_to(:parent_name)
+            end
+          end
+        end
+
+        context 'when multiple fields are specified' do
+          before :all do
+            class Parent
+              include Mongoid::Document
+
+              field :name
+              has_many :children
+            end
+
+            class Child
+              include Mongoid::Document
+              include Mongoid::Denormalize
+
+              belongs_to :parent
+            end
+          end
+
+          after :all do
+            Object.send(:remove_const, :Parent)
+            Object.send(:remove_const, :Child)
+          end
+
+          it 'raises ArgumentError' do
+            expect {
+              Child.denormalize(:first_name, :last_name, from: :parent, as: :supername)
+            }.to raise_error(ArgumentError,
+                             'When option :as is used only one unique field could be specified.')
+          end
+        end
+      end
+
+      context 'when :belongs_to target is polymorphic' do
+        context 'when option :inverses_of is not provided' do
+          before :all do
+            class Parent1
+              include Mongoid::Document
+
+              field :name1
+              has_one :children, inverse_of: :top
+            end
+
+            class Child
+              include Mongoid::Document
+              include Mongoid::Denormalize
+
+              belongs_to :top, polymorphic: true
+            end
+          end
+
+          after :all do
+            Object.send(:remove_const, :Parent1)
+            Object.send(:remove_const, :Child)
+          end
+
+          it 'raises error' do
+            expect {
+              Child.denormalize(:name1, from: :top)
+            }.to raise_error(ArgumentError,
+                             'Option :inverses_of is needed with an Array when the relation is polymorphic.')
+          end
+        end
+
+        context 'when option :as is provided' do
+          before :all do
+            class Parent1
+              include Mongoid::Document
+
+              field :name1
+              has_one :children, inverse_of: :top
+            end
+
+            class Parent2
+              include Mongoid::Document
+
+              field :name2
+              has_one :children, inverse_of: :top
+            end
+
+            class Child
+              include Mongoid::Document
+              include Mongoid::Denormalize
+
+              belongs_to :top, polymorphic: true
+              denormalize :name1, from: :top, inverses_of: %i[parent1], as: :top_name
+              denormalize :name2, from: :top, inverses_of: %i[parent2], as: :top_name
+            end
+          end
+
+          after :all do
+            Object.send(:remove_const, :Parent1)
+            Object.send(:remove_const, :Parent2)
+            Object.send(:remove_const, :Child)
+          end
+
+          context 'when creates new document' do
+            before do
+              @parent = Parent1.create(name1: 'parent')
+              @child = Child.create(top: @parent)
+            end
+
+            it 'has denormalized fields' do
+              expect(@child.reload.top_name).to eq(@parent.name1)
+            end
+
+            it 'doesn\'t create the old from_field' do
+              expect(@child.reload).not_to respond_to(:top_name1)
+              expect(@child.reload).not_to respond_to(:top_name2)
+            end
+          end
+
+          context 'when updates the parent document' do
+            before do
+              @parent = Parent1.create(name1: 'parent')
+              @child = Child.create(top: @parent)
+              @parent.reload.update_attributes(name1: 'new_fancy_name')
+            end
+
+            it 'has denormalized fields' do
+              expect(@child.reload.top_name).to eq(@parent.name1)
+            end
+
+            it 'doesn\'t create the old from_field' do
+              expect(@child.reload).not_to respond_to(:top_name1)
+              expect(@child.reload).not_to respond_to(:top_name2)
+            end
+          end
+        end
+
+        context 'when option :inverses_of is provided' do
+          context 'when fields doesn\'t exists in all the parents' do
+            before :all do
+              class Parent1
+                include Mongoid::Document
+
+                field :name1
+                has_one :children, inverse_of: :top
+              end
+
+              class Parent2
+                include Mongoid::Document
+
+                field :name2
+                has_one :children, inverse_of: :top
+              end
+
+              class Child
+                include Mongoid::Document
+                include Mongoid::Denormalize
+
+                belongs_to :top, polymorphic: true
+                denormalize :name2, :name1, from: :top, inverses_of: %i[parent1 parent2]
+              end
+            end
+
+            after :all do
+              Object.send(:remove_const, :Parent1)
+              Object.send(:remove_const, :Parent2)
+              Object.send(:remove_const, :Child)
+            end
+
+            context 'when creates new document' do
+              it 'has denormalized fields' do
+                parent = Parent1.create!(name1: 'parent')
+                child = Child.create!(top: parent)
+
+                expect(child.reload.top_name1).to eq(parent.name1)
+                expect(child.reload.top_name2).to be_nil
+              end
+            end
+
+            context 'when updates relation' do
+              before do
+                @parent = Parent1.create!(name1: 'parent')
+                @child = Child.create!(top: @parent)
+              end
+
+              context 'with a document of the same type' do
+                before do
+                  @parent_same_type = Parent1.create(name1: 'parent')
+                  @child.update_attributes(top: @parent_same_type)
+                end
+
+                it 'updates denormalized fields' do
+                  expect(@child.reload.top_name1).to eq(@parent_same_type.name1)
+                  expect(@child.reload.top_name2).to be_nil
+                end
+              end
+
+              context 'with a document of different type' do
+                before do
+                  @parent_diff_type = Parent2.create(name2: 'parent')
+                  @child.update_attributes(top: @parent_diff_type)
+                end
+
+                it 'updates denormalized fields' do
+                  expect(@child.reload.top_name2).to eq(@parent_diff_type.name2)
+                  expect(@child.reload.top_name1).to eq(@parent.name1)
+                end
+              end
+            end
+
+            context 'when updates the parent document' do
+              before do
+                @parent = Parent1.create(name1: 'parent')
+                @child = Child.create(top: @parent)
+                @parent.reload.update_attributes(name1: 'new_fancy_name')
+              end
+
+              it 'has denormalized fields' do
+                expect(@child.reload.top_name1).to eq(@parent.name1)
+                expect(@child.reload.top_name2).to be_nil
+              end
+            end
+          end
+
+          context 'when fields exists in all the parents' do
+            before :all do
+              class Parent1
+                include Mongoid::Document
+
+                field :name1
+                has_one :children, inverse_of: :top
+              end
+
+              class Child
+                include Mongoid::Document
+                include Mongoid::Denormalize
+
+                belongs_to :top, polymorphic: true
+                denormalize :name1, from: :top, inverses_of: %i[parent1]
+              end
+            end
+
+            after :all do
+              Object.send(:remove_const, :Parent1)
+              Object.send(:remove_const, :Child)
+            end
+
+            context 'when creates new document' do
+              it 'has denormalized fields' do
+                parent = Parent1.create!(name1: 'parent')
+                child = Child.create!(top: parent)
+
+                expect(child.reload.top_name1).to eq(parent.name1)
+              end
+            end
+
+            context 'when updates the parent document' do
+              it 'has denormalized fields' do
+                parent = Parent1.create(name1: 'parent')
+                child = Child.create(top: parent)
+                parent.reload.update_attributes(name1: 'new_fancy_name')
+
+                expect(child.reload.top_name1).to eq(parent.name1)
+              end
+            end
+          end
+        end
+      end
+
       context 'when :belongs_to target name is diferent from model' do
         before :all do
           class Parent


### PR DESCRIPTION
Added support to polymorphic relations. The final goal of this merge request is to achieve sth like that:

```Ruby
class Notification
  ...
  belongs_to :notifiable, polymorphic: true
  denormalize :name, from: :notifiable, inverses_of: %i[parent1 parent2], as: :notifiable_name
end

class Parent1
  ...
  field :firstname
end

class Parent2
  ...
  field :name
end
```

Hence, this MR also addresses #1 . Let me know your thoughts on this.