### PR TITLE
Travis with different Gemfiles.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.3.4
 before_install: gem install bundler -v 1.15.4
 
-gemfiles:
+gemfile:
   - Gemfile
   - gemfiles/mongoid-5.0.gemfile
   - gemfiles/mongoid-6.0.gemfile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mongoid::Denormalize
-![Build Status](https://travis-ci.org/rjurado01/mongoid-denormalize.svg?branch=master)
+![Build Status](https://travis-ci.org/nosolosoftware/mongoid-denormalize.svg?branch=master)
 
 Helper module for denormalizing association attributes in Mongoid models
 


### PR DESCRIPTION
Added more Gemfiles for testing with mongoid 5 and 6.

The travis status picture, placed in the README.md, was changed in order to
point to the right endpoint.