### PR TITLE
Support for mongoid-7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,13 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.4
-before_install: gem install bundler -v 1.15.4
+  - 2.7
+before_install: gem install bundler -v 2.2
 
 gemfile:
   - Gemfile
-  - gemfiles/mongoid-5.0.gemfile
   - gemfiles/mongoid-6.0.gemfile
+  - gemfiles/mongoid-7.0.gemfile
 
 services:
   - mongodb
-
-addons:
-  apt:
-    sources:
-      - mongodb-3.4-precise
-    packages:
-      - mongodb-org-server

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Mongoid::Denormalize
 ![Build Status](https://travis-ci.org/nosolosoftware/mongoid-denormalize.svg?branch=master)
 
-Helper module for denormalizing association attributes in Mongoid models
+Helper module for denormalizing association attributes in Mongoid models.
+
+This gem is tested on mongoid 6.x and 7.x.
 
 ## Installation
 
@@ -131,7 +133,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/rjurado01/mongoid-denormalize.
+Bug reports and pull requests are welcome on GitHub at https://github.com/nosolosoftware/mongoid-denormalize.
 
 ## License
 

--- a/gemfiles/mongoid-7.0.gemfile
+++ b/gemfiles/mongoid-7.0.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in mongoid-normalize-strings.gemspec
+gemspec path: '../'
+
+gem 'rake'
+gem 'mongoid', "~> 7.0"

--- a/lib/mongoid-denormalize.rb
+++ b/lib/mongoid-denormalize.rb
@@ -85,11 +85,13 @@ module Mongoid
         next if attributes.blank?
 
         case relation.relation.to_s
-        when 'Mongoid::Relations::Referenced::One'
+        when 'Mongoid::Relations::Referenced::One',
+             'Mongoid::Association::Referenced::HasOne::Proxy'
           if (document = send(relation.name))
             document.collection.update_one({_id: document._id}, {'$set' => attributes})
           end
-        when 'Mongoid::Relations::Referenced::Many'
+        when 'Mongoid::Relations::Referenced::Many',
+             'Mongoid::Association::Referenced::HasMany::Proxy'
           send(relation.name).update_all('$set' => attributes)
         else
           raise "Relation type unsupported: #{relation.relation}"

--- a/mongoid-denormalize.gemspec
+++ b/mongoid-denormalize.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'mongoid-compatibility', '~> 0.5.1'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_dependency 'mongoid', ['>= 3.0', '< 7.0']
+  spec.add_dependency 'mongoid', ['>= 6.0', '< 8.0']
 end


### PR DESCRIPTION
This commit add support for mongoid-7.x and drops for versions <= 5.x.